### PR TITLE
Enforce that the first suffix character is in the 0-7 range (spec 0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeID .Net Standard 2.1
 
-## A C# implementation of [TypeIDs](https://github.com/jetpack-io/typeid)
+## A C# implementation of [TypeIDs](https://github.com/jetpack-io/typeid) (Version 0.2.0)
 
 ![License: Apache 2.0](https://img.shields.io/github/license/jetpack-io/typeid-go)
 

--- a/TypeId/TypeId.cs
+++ b/TypeId/TypeId.cs
@@ -63,6 +63,11 @@
                 return false;
             }
 
+            if (suffix[0] > '7')
+            {
+                return false;
+            }
+
             foreach (var c in suffix)
             {
                 if (!char.IsLetterOrDigit(c))

--- a/TypeIdTests/SpecTests.cs
+++ b/TypeIdTests/SpecTests.cs
@@ -13,7 +13,7 @@
         public void Initialize()
         {
             /*
-             * Last updated: 2023-06-29
+             * Last updated: 2023-07-05
              */
 
             var validitiesByFilePath = new Dictionary<string, bool>

--- a/TypeIdTests/SpecTests/invalid.yml
+++ b/TypeIdTests/SpecTests/invalid.yml
@@ -4,7 +4,7 @@
 # Each example contains an invalid TypeID string. Implementations are expected
 # to throw an error when attempting to parse/validate these strings.
 #
-# Last updated: 2023-06-29
+# Last updated: 2023-07-05
 
 - name: prefix-uppercase
   typeid: "PREFIX_00000000000000000000000000"
@@ -31,7 +31,7 @@
   description: "The prefix can't have any spaces"
 
 - name: prefix-64-chars
-  #          123456789 123456789 123456789 123456789 123456789 123456789 1234
+  #        123456789 123456789 123456789 123456789 123456789 123456789 1234
   typeid: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl_00000000000000000000000000"
   description: "The prefix can't be 64 characters, it needs to be 63 characters or less"
 
@@ -81,3 +81,8 @@
   # This example would be valid if we were using the crockford hyphenation rules
   typeid: "prefix_123456789-0123456789-0123456"
   description: "The suffix can't ignore hyphens as in the crockford encoding"
+
+- name: suffix-overflow
+  # This is the first suffix that overflows into 129 bits
+  typeid: "prefix_8zzzzzzzzzzzzzzzzzzzzzzzzz"
+  description: "The should encode at most 128-bits"

--- a/TypeIdTests/SpecTests/valid.yml
+++ b/TypeIdTests/SpecTests/valid.yml
@@ -23,7 +23,7 @@
 # note that not all of them are UUIDv7s. When *generating* new random typeids,
 # implementations should always use UUIDv7s.
 #
-# Last updated: 2023-06-29
+# Last updated: 2023-07-05
 
 - name: nil
   typeid: "00000000000000000000000000"
@@ -49,6 +49,11 @@
   typeid: "00000000000000000000000010"
   prefix: ""
   uuid: "00000000-0000-0000-0000-000000000020"
+
+- name: max-valid
+  typeid: "7zzzzzzzzzzzzzzzzzzzzzzzzz"
+  prefix: ""
+  uuid: "ffffffff-ffff-ffff-ffff-ffffffffffff"
 
 - name: valid-alphabet
   typeid: "prefix_0123456789abcdefghjkmnpqrs"


### PR DESCRIPTION
Based on PR https://github.com/jetpack-io/opensource/pull/75

This PR:
1. Updates the test data files
2. Updates suffix validataion  